### PR TITLE
Broken link in TFX cli.md

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -88,7 +88,7 @@ tfx pipeline create --pipeline_path=<var>pipeline-path</var> [--endpoint=<var>en
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>
@@ -214,7 +214,7 @@ tfx pipeline update --pipeline_path=<var>pipeline-path</var> [--endpoint=<var>en
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>
@@ -391,7 +391,7 @@ tfx pipeline delete --pipeline_path=<var>pipeline-path</var> [--endpoint=<var>en
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>
@@ -484,7 +484,7 @@ tfx pipeline list [--endpoint=<var>endpoint</var> --engine=<var>engine</var> \
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>
@@ -591,7 +591,7 @@ tfx run create --pipeline_name=<var>pipeline-name</var> [--endpoint=<var>endpoin
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>
@@ -688,7 +688,7 @@ tfx run terminate --run_id=<var>run-id</var> [--endpoint=<var>endpoint</var> --e
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>
@@ -770,7 +770,7 @@ tfx run list --pipeline_name=<var>pipeline-name</var> [--endpoint=<var>endpoint<
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>
@@ -861,7 +861,7 @@ tfx run status --pipeline_name=<var>pipeline-name</var> --run_id=<var>run-id</va
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>
@@ -950,7 +950,7 @@ tfx run delete --run_id=<var>run-id</var> [--engine=<var>engine</var> --iap_clie
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>
@@ -1102,7 +1102,7 @@ tfx template copy --model=<var>model</var> --pipeline_name=<var>pipeline-name</v
       If the <code>--endpoint</code> is not specified, the in-cluster service
       DNS name is used as the default value. This name works only if the
       CLI command executes in a pod on the Kubeflow Pipelines cluster, such as a
-      <a href="https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/"
+      <a href="https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/"
            class="external">Kubeflow Jupyter notebooks</a> instance.
     </p>
   </dd>


### PR DESCRIPTION
Upadated the correct link(https://www.kubeflow.org/docs/components/notebooks/why-use-jupyter-notebook/) in place of dead link(https://www.kubeflow.org/docs/notebooks/why-use-jupyter-notebook/).Throwing 404 error